### PR TITLE
Add prometheus retention config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--storage.tsdb.retention.size=1TB'
     ports:
       - 9090:9090
     networks:


### PR DESCRIPTION
Without a retention time or size flag prometheus defaults to deleting any data older than 15d. The data we are using to debug can be older than 15d, so prometheus will delete it when it starts up.